### PR TITLE
Fixed broken links in CONTRIBUTING, ci, and preface files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ temp_dir
 /.idea/vcs.xml
 
 .DS_Store
+
+.venv/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the Gradle Cookbook
 
-[![a](https://img.shields.io/badge/slack-%23docs-brightgreen?style=flat&logo=slack)](./contributing/community-slack.md)
+[![a](https://img.shields.io/badge/slack-%23docs-brightgreen?style=flat&logo=slack)](https://gradle.org/slack-invite)
 
 
 The Gradle Cookbook is under active development.
@@ -8,7 +8,7 @@ Any contributions are welcome!
 
 ## Discuss
 
-- `#docs` on the [Gradle Community Slack](../contributing/community-slack.md)
+- `#docs` on the [Gradle Community Slack](https://gradle.org/slack-invite)
 - [GitHub Issues](https://github.com/gradle/community/issues)
 
 ## Development Environment

--- a/docs/ci/github-actions.md
+++ b/docs/ci/github-actions.md
@@ -54,7 +54,7 @@ $ git push
 
 ### Test building the project
 
-The project uses the [Gradle Wrapper](gradle_wrapper.adoc#gradle_wrapper_reference) for building the project. It is a recommended practice for any Gradle project as it enables your project to be built on CI without having to install the Gradle runtime.
+The project uses the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) for building the project. It is a recommended practice for any Gradle project as it enables your project to be built on CI without having to install the Gradle runtime.
 
 Before asking GitHub Actions to build your project, it's useful to ensure that it builds locally. Adding the "CI" environment variable will emulate running the build on GitHub Actions.
 

--- a/docs/ci/jenkins.md
+++ b/docs/ci/jenkins.md
@@ -39,7 +39,7 @@ BUILD SUCCESSFUL
 14 actionable tasks: 14 executed
 ```
 
-The project provides the [Gradle Wrapper](gradle_wrapper.adoc#gradle_wrapper_reference) as part of the repository. It is a recommended practice for any Gradle project as it enables your project to be built on CI without having to install the Gradle runtime.
+The project provides the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) as part of the repository. It is a recommended practice for any Gradle project as it enables your project to be built on CI without having to install the Gradle runtime.
 
 ### Build scan integration
 

--- a/docs/ci/teamcity.md
+++ b/docs/ci/teamcity.md
@@ -38,7 +38,7 @@ BUILD SUCCESSFUL
 14 actionable tasks: 14 executed
 ```
 
-The project provides the [Gradle Wrapper](gradle_wrapper.adoc#gradle_wrapper_reference) as part of the repository. It is a recommended practice for any Gradle project as it enables your project to be built on CI without having to install the Gradle runtime.
+The project provides the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) as part of the repository. It is a recommended practice for any Gradle project as it enables your project to be built on CI without having to install the Gradle runtime.
 
 ### Build scan integration
 

--- a/docs/ci/travis-ci.md
+++ b/docs/ci/travis-ci.md
@@ -38,7 +38,7 @@ BUILD SUCCESSFUL
 14 actionable tasks: 14 executed
 ```
 
-The project provides the [Gradle Wrapper](gradle_wrapper.adoc#gradle_wrapper_reference) as part of the repository. It is a recommended practice for any Gradle project as it enables your project to be built on CI without having to install the Gradle runtime.
+The project provides the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) as part of the repository. It is a recommended practice for any Gradle project as it enables your project to be built on CI without having to install the Gradle runtime.
 
 ### Build scan integration
 

--- a/docs/preface.md
+++ b/docs/preface.md
@@ -56,4 +56,4 @@ trademark usage and the approval process.
 ## References
 
 - [Gradle User Manual](https://docs.gradle.org/current/userguide/userguide.html)
-- [Other Documentation Locations](../contributing/documentation/README.md/#locations)
+- [Other Documentation Locations](https://community.gradle.org/contributing/documentation)


### PR DESCRIPTION
Fixed links by replacing markdown links to normal https links in some pages

Also added .venv/ to .gitignore because I'm using a python virtual environment for using mkdocs