### PR TITLE
Fixed broken links in docs/android and docs/ci folders

### DIFF
--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -105,7 +105,7 @@ Gradle provides various options to improve build performance, including **build 
 org.gradle.parallel=true
 ```
 
-To explore more optimization techniques and configure your builds for better performance, check out our detailed guide: [Gradle Build Optimization](docs/android/optimization.md). 
+To explore more optimization techniques and configure your builds for better performance, check out our detailed guide: [Gradle Build Optimization](../../docs/android/optimization.md). 
 
 For further information, visit the **official**  [Optimizing Builds Guide](https://developer.android.com/build/optimize-your-build).
 
@@ -142,7 +142,7 @@ configurations.all {
 ```
 For more troubleshooting tips, visit the **official**  [Troubleshooting AGP](https://developer.android.com/build/troubleshoot) page.
 
-You can also check the [Gradle Troubleshooting](docs/android/troubleshooting.md) page for additional help with Gradle-specific issues.
+You can also check the [Gradle Troubleshooting](../../docs/android/troubleshooting.md) page for additional help with Gradle-specific issues.
 
 ## References
 

--- a/docs/android/optimization.md
+++ b/docs/android/optimization.md
@@ -2,8 +2,8 @@
 
 This page references key external resources to help you optimize your Android Gradle builds. Below are some techniques and guides:
 
-- [Build Caching](https://developer.android.com/build/optimize-your-build#build-cache) – Reduce unnecessary tasks by reusing outputs from previous builds.
-- [Parallel Execution](https://developer.android.com/build/optimize-your-build#parallel-execution) – Execute independent tasks in parallel to speed up the build.
-- [Gradle Daemon](https://developer.android.com/build/optimize-your-build#gradle-daemon) – Optimize build performance by using a persistent process for faster execution.
+- [Build Caching](https://developer.android.com/build/optimize-your-build#use-the-configuration-cache) – Reduce unnecessary tasks by reusing outputs from previous builds.
+- [Parallel Execution](https://docs.gradle.org/current/userguide/performance.html#parallel_execution) – Execute independent tasks in parallel to speed up the build.
+- [Gradle Daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#enable_deamon) – Optimize build performance by using a persistent process for faster execution.
 
 More original content will be added soon to cover performance monitoring, advanced caching strategies, and Gradle tuning specific to large-scale projects.

--- a/docs/ci/github-actions.md
+++ b/docs/ci/github-actions.md
@@ -1,7 +1,7 @@
 # Executing Gradle builds on GitHub Actions
 
 !!! tip
-    Top engineering teams using GitHub Actions have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://gradle.org/training/#build-cache-deep-dive) for our Build Cache training session to learn how your team can achieve similar results.
+    Top engineering teams using TeamCity have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0) for our Build Cache training session to learn how your team can achieve similar results.
 
 Building Gradle projects doesn't stop with the developer's machine. [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) has been a long-established practice for running a build for every single change committed to version control to tighten the feedback loop.
 

--- a/docs/ci/github-actions.md
+++ b/docs/ci/github-actions.md
@@ -1,7 +1,7 @@
 # Executing Gradle builds on GitHub Actions
 
 !!! tip
-    Top engineering teams using TeamCity have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0) for our Build Cache training session to learn how your team can achieve similar results.
+    Top engineering teams using GitHub Actions have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0) for our Build Cache training session to learn how your team can achieve similar results.
 
 Building Gradle projects doesn't stop with the developer's machine. [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) has been a long-established practice for running a build for every single change committed to version control to tighten the feedback loop.
 

--- a/docs/ci/jenkins.md
+++ b/docs/ci/jenkins.md
@@ -1,7 +1,7 @@
 # Executing Gradle builds on Jenkins
 
 !!! tip
-    Top engineering teams using Jenkins have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://gradle.org/training/#build-cache-deep-dive) for our Build Cache training session to learn how your team can achieve similar results.
+    Top engineering teams using Jenkins have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0) for our Build Cache training session to learn how your team can achieve similar results.
 
 Building Gradle projects doesn't stop with the developer's machine. [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) has been a long-established practice for running a build for every single change committed to version control to tighten the feedback loop.
 

--- a/docs/ci/teamcity.md
+++ b/docs/ci/teamcity.md
@@ -1,7 +1,7 @@
 # Executing Gradle builds on TeamCity
 
 !!! tip
-     Top engineering teams using TeamCity have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://gradle.org/training/#build-cache-deep-dive) for our Build Cache training session to learn how your team can achieve similar results.
+    Top engineering teams using TeamCity have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0) for our Build Cache training session to learn how your team can achieve similar results.
 
 Building Gradle projects doesn't stop with the developer's machine. [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) has been a long-established practice for running a build for every single change committed to version control to tighten the feedback loop.
 

--- a/docs/ci/travis-ci.md
+++ b/docs/ci/travis-ci.md
@@ -1,7 +1,7 @@
 # Executing Gradle builds on Travis CI
 
 !!! tip
-    Top engineering teams using Travis CI have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://gradle.org/training/#build-cache-deep-dive) for our Build Cache training session to learn how your team can achieve similar results.
+    Top engineering teams using Travis CI have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. [Register here](https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0) for our Build Cache training session to learn how your team can achieve similar results.
 
 Building Gradle projects doesn't stop with the developer's machine. [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI) has been a long-established practice for running a build for every single change committed to version control to tighten the feedback loop.
 
@@ -60,7 +60,7 @@ Travis CI is a free, cloud-based CI solution provider making it an excellent cho
 
 Travis CI requires you to check in a [configuration file](https://docs.travis-ci.com/user/customizing-the-build/) with your source code named `.travis.yml`. This file contains all relevant instructions for building the project.
 
-The following configuration file tells Travis CI to build a Java project with JDK 8, skip the usual [default execution step](https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step), and run the Gradle build with the Wrapper.
+The following configuration file tells Travis CI to build a Java project with JDK 8, skip the usual [default execution step](https://docs.travis-ci.com/user/job-lifecycle/#skip-the-installation-phase), and run the Gradle build with the Wrapper.
 
 ```yaml
 language: java
@@ -82,7 +82,7 @@ Select the project from the Travis CI profile. After activating the repository f
 
 ### Enable caching of downloaded artifacts
 
-Gradle's dependency management mechanism resolves declared modules and their corresponding artifacts from a binary repository. Once downloaded, the files will be re-used from the cache. You need to tell Travis CI explicitly that you want to [store and use the Gradle cache and Wrapper](https://docs.travis-ci.com/user/languages/java/#Caching) for successive invocations of the build.
+Gradle's dependency management mechanism resolves declared modules and their corresponding artifacts from a binary repository. Once downloaded, the files will be re-used from the cache. You need to tell Travis CI explicitly that you want to [store and use the Gradle cache and Wrapper](https://docs.travis-ci.com/user/languages/java/#caching) for successive invocations of the build.
 
 ```yaml
 before_cache:


### PR DESCRIPTION
Fixed links by replacing markdown links by https ones which point to the gradle community docs

Also changed 2 android.com links (in docs/android/optimization.md) to point to gradle community docs of the same features (only for the articles that don't contain the original feature anymore)