### PR TITLE
Add initial boilerplate for Configuration Cache plugin developer tips

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -9,6 +9,7 @@ mkdocs-macros-plugin==1.0.5
 mkdocs-material==9.5.17
 mkdocs-material[imaging]==9.5.17
 mkdocs-multirepo-plugin==0.6.3
+mkdocs-nav-weight==0.2.0
 mkdocs-redirects==1.2.1
 mkdocs-extra-sass-plugin==0.1.0
 mkdocs-render-swagger-plugin==0.1.1

--- a/docs/plugin-development/README.md
+++ b/docs/plugin-development/README.md
@@ -3,5 +3,5 @@
 ## Recipes
 
 - [Writing Gradle plugins in Kotlin](./kotlin-plugins.md)
-
+- [Ensuring Configuration Cache compatibility](./configuration-cache/README.md)
 

--- a/docs/plugin-development/configuration-cache/README.md
+++ b/docs/plugin-development/configuration-cache/README.md
@@ -2,14 +2,16 @@
 
 The configuration and execution phase of builds always take the longest.
 You may already know about the build cache, which saves execution time by reusing outputs from past builds. 
-The new [Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html) feature reuses configuration results from past builds to speed up the configuration phase.
+Gradle's [Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html),
+introduced in 6.6 and becoming a preferred mode of execution in Gradle 10,
+reuses configuration results from past builds to speed up the configuration phase.
 
 If you keep an eye on [Gradle public roadmap updates](https://roadmap.gradle.org),
-you've probably noticed lots of work on the configuration cache.
-This feature is almost finished incubating -- expect to see a stable release soon.
-Still, there is a lot of work to be done in the plugins,
-many Gradle tasks still need to have configuration cache compatibility.
-We track the status on [this GitHub Issue](https://github.com/gradle/gradle/issues/13490), and any contributions are more than welcome.
+you've probably noticed lots of improvements in Configuration Cache, and steady adoption in the ecosystem.
+Still, there is a lot of work to be done in the plugins.
+Many Gradle plugins still need to have configuration cache compatibility, and also updates might be needed in end user builds and convention plugins.
+For the community plugins for Gradle,
+we track the status on [this GitHub Issue](https://github.com/gradle/gradle/issues/13490), and any contributions are more than welcome!
 
 On this page, we focus on tips for plugins developers and contributors who want to fix Configuration Cache (CC) compatibility in their projects.
 

--- a/docs/plugin-development/configuration-cache/README.md
+++ b/docs/plugin-development/configuration-cache/README.md
@@ -1,0 +1,46 @@
+# Ensuring Configuration Cache compatibility
+
+The configuration and execution phase of builds always take the longest.
+You may already know about the build cache, which saves execution time by reusing outputs from past builds. 
+The new [Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html) feature reuses configuration results from past builds to speed up the configuration phase.
+
+If you keep an eye on [Gradle public roadmap updates](https://roadmap.gradle.org),
+you've probably noticed lots of work on the configuration cache.
+This feature is almost finished incubating -- expect to see a stable release soon.
+Still, there is a lot of work to be done in the plugins,
+many Gradle tasks still need to have configuration cache compatibility.
+We track the status on [this GitHub Issue](https://github.com/gradle/gradle/issues/13490), and any contributions are more than welcome.
+
+On this page, we focus on tips for plugins developers and contributors who want to fix Configuration Cache (CC) compatibility in their projects.
+
+## Main Documentation
+
+For Configuration Cache adoption and troubleshooting steps, you can already find information
+in the main documentation:
+
+- [Troubleshooting Configuration Cache compatibility](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:troubleshooting)
+- [Configuration Cache Adoption Steps](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:adoption)
+- [Auto-testing configuration Cache compatibility](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:testing)
+
+
+## FAQ
+
+### How to fix "invocation of 'Task.project' at execution time is unsupported"?
+
+In essence, you should use an alternative service that provides similar functionality. See "Using the Project object" in the [Configuration Cache documentation](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution). See a sample [fix](https://github.com/gradle/gradle/pull/21555/files#r948986470).
+
+Also, the configuration cache serialization logic handles `Provider<T>` specially and correctly serializes their values; use `Property<T>` and the providers returned from `org.gradle.api.provider.ProviderFactory` to store values captured from the project or the properties.
+
+### How to fix "cannot serialize Gradle script object references"?
+
+This problem most commonly signals that a member of the enclosing script scope, for instance, a member of the `Project` object in the case of project scripts, is being used by a task action:
+
+```kotlin
+tasks.register("printProjectVersion") {
+    doLast {
+        println(version) // <---- Project.version captured by a task action
+    }
+}
+```
+
+A common example is when the `configurations` property or a configuration object (like `runtimeClasspath`) is used by a doLast/doFirst action. Avoid accessing such objects during execution. See a [fix](https://github.com/gradle/gradle/pull/21555/files#r948983984).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Plugin Development:
     - Summary: plugin-development/README.md
     - Kotlin plugin development: plugin-development/kotlin-plugins.md
+    - Ensuring Configuration Cache compatibility: plugin-development/configuration-cache/
 
 # Theme
 theme:
@@ -149,6 +150,9 @@ plugins:
   - git-committers:
       repository: gradle/cookbook
       branch: main
+  - mkdocs-nav-weight:
+      # Index/README go first in folder includes
+      index_weight: -10
 
   - with-pdf:
       enabled_if_env: BUILD_PDF


### PR DESCRIPTION
First edition of the additional developer support page for https://github.com/gradle/gradle/issues/13490 