### PR TITLE
Fix: Broken links on README page

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you plan to add a new major category, it's better to discuss it in advance.
 
 ## Previews
 
-For any pull equest with the approved GitHub Actions run,
+For any pull request with the approved GitHub Actions run,
 a preview site will be deployed.
 The build both will share the link in the comments to the pull request.
 

--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -105,7 +105,7 @@ Gradle provides various options to improve build performance, including **build 
 org.gradle.parallel=true
 ```
 
-To explore more optimization techniques and configure your builds for better performance, check out our detailed guide: [Gradle Build Optimization](../../docs/android/optimization.md). 
+To explore more optimization techniques and configure your builds for better performance, check out our detailed guide: [Gradle Build Optimization](./optimization.md). 
 
 For further information, visit the **official**  [Optimizing Builds Guide](https://developer.android.com/build/optimize-your-build).
 
@@ -142,7 +142,7 @@ configurations.all {
 ```
 For more troubleshooting tips, visit the **official**  [Troubleshooting AGP](https://developer.android.com/build/troubleshoot) page.
 
-You can also check the [Gradle Troubleshooting](../../docs/android/troubleshooting.md) page for additional help with Gradle-specific issues.
+You can also check the [Gradle Troubleshooting](./troubleshooting.md) page for additional help with Gradle-specific issues.
 
 ## References
 


### PR DESCRIPTION
This PR resolves an issue on the Gradle for Android's page.

#### How to reproduce this issue
When clicking on the 'Gradle Build Optimization' or 'Gradle Troubleshooting' links, a `404 - Not found` error is presented.