### PR TITLE
Updated Gradle Reporting API

### DIFF
--- a/docs/plugin-development/reporting-api/README.md
+++ b/docs/plugin-development/reporting-api/README.md
@@ -15,6 +15,8 @@ object.
 We’ll be working with the [VerifyPluginProjectConfigurationTask](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/476130fa41347ef4e5480fb44b9d454e51aa7a18/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/VerifyPluginProjectConfigurationTask.kt#L44), a task from the [IntelliJ Platform Gradle Plugin](https://github.com/JetBrains/intellij-platform-gradle-plugin/tree/476130fa41347ef4e5480fb44b9d454e51aa7a18) 
 that does the simple job of validating a plugin project’s configuration.
 
+## Declaring Reporting Support in a Task
+
 Tasks that produce reports must implement the `Reporting` interface with a type argument that extends `ReportContainer`:
 
 ```kotlin
@@ -22,6 +24,8 @@ abstract class VerifyPluginProjectConfigurationTask : DefaultTask(), Reporting<V
     // skipped lines
 }
 ```
+
+## Defining the `ReportContainer` Contract
 
 `VerifyPluginConfigurationReports` is an interface that extends `ReportContainer<SingleFileReport>`. `SingleFileReport` 
 is a useful wrapper around `Report` that represents that our output will be a single file. If your report was a group of files 
@@ -60,6 +64,8 @@ class VerifyPluginConfigurationReportsImpl : VerifyPluginConfigurationReports {
 
 }
 ```
+
+## Implementing the `ReportContainer`
 
 Providing an implementation of our report container requires that we override over 40 different methods. 
 To avoid doing this, we can delegate access to these methods to another `ReportContainer` class with the help of `DelegatingReportContainer`. 
@@ -112,6 +118,8 @@ class VerifyPluginConfigurationReportsImpl @Inject constructor(
 }
 ```
 
+## Wiring the `ReportContainer` into the Task
+
 After defining our report container and report objects, back to our task to start working with them:
 
 ```kotlin
@@ -163,6 +171,8 @@ abstract class VerifyPluginProjectConfigurationTask : DefaultTask(), Reporting<V
 
 We annotate `getReports()` with `@Nested` so Gradle inspects the returned report container’s properties (like `txt`, `html`, `markdown`) and their annotations.
 
+## Setting up Report Outputs
+
 When configuring our task, we can go ahead to use our function to set up our reports:
 
 ```kotlin
@@ -171,6 +181,8 @@ reports {
     txt.outputLocation.convention(project.layout.buildDirectory.file("reports/verifyPluginConfiguration/report.txt"))
 }
 ```
+
+## Writing Data to Reports
 
 Finally, writing to our reports can be done in this fashion:
 

--- a/docs/plugin-development/reporting-api/README.md
+++ b/docs/plugin-development/reporting-api/README.md
@@ -15,6 +15,9 @@ object.
 We’ll be working with the [VerifyPluginProjectConfigurationTask](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/476130fa41347ef4e5480fb44b9d454e51aa7a18/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/VerifyPluginProjectConfigurationTask.kt#L44), a task from the [IntelliJ Platform Gradle Plugin](https://github.com/JetBrains/intellij-platform-gradle-plugin/tree/476130fa41347ef4e5480fb44b9d454e51aa7a18) 
 that does the simple job of validating a plugin project’s configuration.
 
+!!! note
+    Tested with Gradle 9.0.0
+
 ## Declaring Reporting Support in a Task
 
 Tasks that produce reports must implement the `Reporting` interface with a type argument that extends `ReportContainer`:
@@ -194,11 +197,10 @@ if (verifyPluginProjectReports.txt.required.get()) {
 
 ## References
 
-- https://docs.gradle.org/current/dsl/org.gradle.api.reporting.ReportContainer.html
-- https://docs.gradle.org/current/dsl/org.gradle.api.reporting.Reporting.html
-- https://docs.gradle.org/current/dsl/org.gradle.api.reporting.Report.html
-- https://docs.gradle.org/current/dsl/org.gradle.api.reporting.SingleFileReport.html
-- https://docs.gradle.org/current/dsl/org.gradle.api.reporting.DirectoryReport.html
-- https://github.com/gradle/gradle/issues/7063
-
-Tested with: Gradle 9.0.0
+- [PR for VerifyPluginProjectConfigurationTask, GSoC 2025](https://github.com/JetBrains/intellij-platform-gradle-plugin/pull/2016)
+- [ReportContainer DSL](https://docs.gradle.org/current/dsl/org.gradle.api.reporting.ReportContainer.html)
+- [Reporting DSL](https://docs.gradle.org/current/dsl/org.gradle.api.reporting.Reporting.html)
+- [Report DSL](https://docs.gradle.org/current/dsl/org.gradle.api.reporting.Report.html)
+- [SingleFileReport DSL](https://docs.gradle.org/current/dsl/org.gradle.api.reporting.SingleFileReport.html)
+- [DirectoryReport DSL](https://docs.gradle.org/current/dsl/org.gradle.api.reporting.DirectoryReport.html)
+- [https://github.com/gradle/gradle/issues/7063](https://github.com/gradle/gradle/issues/7063)


### PR DESCRIPTION
This PR addresses [feedback](https://gradle-community.slack.com/archives/CAB4AE8TA/p1756277949327389) from @oleg-nenashev to improve the Gradle Reporting API cookbook entry:

- Split the content into smaller, structured sections with descriptive headers.
- Updated the “References” section so hyperlinks render correctly in the current MkDocs configuration.
- Added a reference to my GSoC 2025 project
- Moved the “Tested with: Gradle 9.0.0” note into an admonition at the top of the page